### PR TITLE
Micrometer support for all Spring Cloud Task App Starters

### DIFF
--- a/core-dependencies/pom.xml
+++ b/core-dependencies/pom.xml
@@ -11,18 +11,19 @@
 	<parent>
 		<artifactId>spring-cloud-dependencies-parent</artifactId>
 		<groupId>org.springframework.cloud</groupId>
-		<version>2.1.3.RELEASE</version>
+		<version>2.2.0.BUILD-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 
 	<properties>
 		<java.version>1.8</java.version>
-		<spring-cloud-task.version>2.1.1.RELEASE</spring-cloud-task.version>
-		<spring.cloud.dependencies.version>Greenwich.SR1</spring.cloud.dependencies.version>
-		<spring.cloud.deployer.spi>2.0.0.RELEASE</spring.cloud.deployer.spi>
-		<spring.cloud.deployer.resource.maven>2.0.0.RELEASE</spring.cloud.deployer.resource.maven>
+		<spring-cloud-task.version>2.2.0.BUILD-SNAPSHOT</spring-cloud-task.version>
+		<spring.cloud.dependencies.version>Greenwich.SR2</spring.cloud.dependencies.version>
+		<spring.cloud.deployer.spi>2.0.2.RELEASE</spring.cloud.deployer.spi>
+		<spring.cloud.deployer.resource.maven>2.0.2.RELEASE</spring.cloud.deployer.resource.maven>
 		<hibernate.validation.version>6.0.14.Final</hibernate.validation.version>
 		<log4j.version>1.2.17</log4j.version>
+		<java-cfenv-boot.version>1.0.1.RELEASE</java-cfenv-boot.version>
 	</properties>
 
 	<dependencyManagement>
@@ -40,6 +41,11 @@
 				<version>${spring.cloud.dependencies.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.springframework.cloud.task.app</groupId>
+				<artifactId>task-app-starters-micrometer-common</artifactId>
+				<version>2.1.1.BUILD-SNAPSHOT</version>
 			</dependency>
 			<dependency>
 				<groupId>org.springframework.cloud</groupId>
@@ -60,6 +66,11 @@
 				<groupId>log4j</groupId>
 				<artifactId>log4j</artifactId>
 				<version>${log4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.pivotal.cfenv</groupId>
+				<artifactId>java-cfenv-test-support</artifactId>
+				<version>${java-cfenv-boot.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.cloud.task.app</groupId>
 	<artifactId>task-app-starters-build</artifactId>
@@ -9,8 +10,8 @@
 	<parent>
 		<groupId>org.springframework.cloud</groupId>
 		<artifactId>spring-cloud-build</artifactId>
-		<version>2.1.3.RELEASE</version>
-		<relativePath />
+		<version>2.2.0.M2</version>
+		<relativePath/>
 	</parent>
 	<scm>
 		<connection>scm:git:git://github.com/spring-cloud/spring-cloud-task-app-starters.git</connection>
@@ -29,6 +30,7 @@
 
 	<modules>
 		<module>core-dependencies</module>
+		<module>task-app-starters-common</module>
 	</modules>
 
 	<dependencyManagement>
@@ -162,6 +164,22 @@
 									</bom>
 								</additionalBoms>
 								<additionalGlobalDependencies>
+									<dependency>
+										<groupId>org.springframework.cloud.task.app</groupId>
+										<artifactId>task-app-starters-micrometer-common</artifactId>
+									</dependency>
+									<dependency>
+										<groupId>org.springframework.boot</groupId>
+										<artifactId>spring-boot-starter-actuator</artifactId>
+									</dependency>
+									<dependency>
+										<groupId>io.micrometer</groupId>
+										<artifactId>micrometer-registry-influx</artifactId>
+									</dependency>
+									<dependency>
+										<groupId>io.micrometer</groupId>
+										<artifactId>micrometer-registry-prometheus</artifactId>
+									</dependency>
 									<dependency>
 										<groupId>org.springframework.cloud</groupId>
 										<artifactId>spring-cloud-starter-config</artifactId>

--- a/task-app-starters-common/pom.xml
+++ b/task-app-starters-common/pom.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>task-app-starters-build</artifactId>
+		<groupId>org.springframework.cloud.task.app</groupId>
+		<version>2.1.1.BUILD-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>task-app-starters-common</artifactId>
+	<packaging>pom</packaging>
+	<modules>
+		<module>task-app-starters-micrometer-common</module>
+	</modules>
+
+</project>

--- a/task-app-starters-common/task-app-starters-micrometer-common/pom.xml
+++ b/task-app-starters-common/task-app-starters-micrometer-common/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<artifactId>task-app-starters-common</artifactId>
+		<groupId>org.springframework.cloud.task.app</groupId>
+		<version>2.1.1.BUILD-SNAPSHOT</version>
+	</parent>
+	<modelVersion>4.0.0</modelVersion>
+
+	<artifactId>task-app-starters-micrometer-common</artifactId>
+	<name>task-app-starters-micrometer-common</name>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-influx</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.pivotal.cfenv</groupId>
+			<artifactId>java-cfenv-test-support</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+	</dependencies>
+
+
+</project>

--- a/task-app-starters-common/task-app-starters-micrometer-common/src/main/java/org/springframework/cloud/task/app/micrometer/common/SpringCloudTaskMicrometerEnvironmentPostProcessor.java
+++ b/task-app-starters-common/task-app-starters-micrometer-common/src/main/java/org/springframework/cloud/task/app/micrometer/common/SpringCloudTaskMicrometerEnvironmentPostProcessor.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.task.app.micrometer.common;
+
+import java.util.Properties;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.env.EnvironmentPostProcessor;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.PropertiesPropertySource;
+
+/**
+ * Disables all Micrometer Repositories added as App Starters dependencies by default.
+ * That means disabling Datadog, Influx and Prometheus.
+ *
+ * @author Christian Tzolov
+ */
+public class SpringCloudTaskMicrometerEnvironmentPostProcessor implements EnvironmentPostProcessor {
+
+	protected static final String PROPERTY_SOURCE_KEY_NAME = SpringCloudTaskMicrometerEnvironmentPostProcessor.class.getName();
+
+	private final static String METRICS_PROPERTY_NAME_TEMPLATE = "management.metrics.export.%s.enabled";
+
+	private final static String[] METRICS_REPOSITORY_NAMES = new String[] { "datadog", "influx", "prometheus" };
+
+	@Override
+	public void postProcessEnvironment(ConfigurableEnvironment environment, SpringApplication application) {
+		Properties properties = new Properties();
+
+		for (String metricsRepositoryName : METRICS_REPOSITORY_NAMES) {
+			String metricsEnabledPropertyKey = String.format(METRICS_PROPERTY_NAME_TEMPLATE, metricsRepositoryName);
+
+			// Back off if the property is already set externally
+			if (!environment.containsProperty(metricsEnabledPropertyKey)) {
+				properties.setProperty(metricsEnabledPropertyKey, "false");
+			}
+		}
+
+		// Ensure  idempotency as this post-processor is called multiple times (once for each application context)
+		// but the properties should be set only once.
+		if (!properties.isEmpty()) {
+			environment.getPropertySources().addLast(new PropertiesPropertySource(PROPERTY_SOURCE_KEY_NAME, properties));
+		}
+	}
+}

--- a/task-app-starters-common/task-app-starters-micrometer-common/src/main/resources/META-INF/spring.factories
+++ b/task-app-starters-common/task-app-starters-micrometer-common/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+org.springframework.boot.env.EnvironmentPostProcessor=\
+org.springframework.cloud.task.app.micrometer.common.SpringCloudTaskMicrometerEnvironmentPostProcessor
+

--- a/task-app-starters-common/task-app-starters-micrometer-common/src/test/java/org/springframework/cloud/task/app/micrometer/common/AbstractMicrometerTagTest.java
+++ b/task-app-starters-common/task-app-starters-micrometer-common/src/test/java/org/springframework/cloud/task/app/micrometer/common/AbstractMicrometerTagTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2018-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.task.app.micrometer.common;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.Before;
+import org.junit.runner.RunWith;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimpleProperties;
+import org.springframework.boot.actuate.autoconfigure.metrics.export.simple.SimplePropertiesConfigAdapter;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * @author Christian Tzolov
+ * @author Soby Chacko
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = AbstractMicrometerTagTest.AutoConfigurationApplication.class)
+public class AbstractMicrometerTagTest {
+
+	@Autowired
+	protected SimpleMeterRegistry simpleMeterRegistry;
+
+	@Autowired
+	protected ConfigurableApplicationContext context;
+
+	protected Meter meter;
+
+	@Before
+	public void before() {
+		assertNotNull(simpleMeterRegistry);
+		meter = simpleMeterRegistry.find("jvm.memory.committed").meter();
+		assertNotNull("The jvm.memory.committed meter mast be present in SpringBoot apps!", meter);
+	}
+
+	@SpringBootApplication
+	@EnableConfigurationProperties(SimpleProperties.class)
+	public static class AutoConfigurationApplication {
+
+		public static void main(String[] args) {
+			SpringApplication.run(AutoConfigurationApplication.class, args);
+		}
+
+		@Bean
+		public SimpleMeterRegistry simpleMeterRegistry(SimpleConfig config, Clock clock) {
+			return new SimpleMeterRegistry(config, clock);
+		}
+
+		@Bean
+		@ConditionalOnMissingBean
+		public SimpleConfig simpleConfig(SimpleProperties simpleProperties) {
+			return new SimplePropertiesConfigAdapter(simpleProperties);
+		}
+	}
+}

--- a/task-app-starters-common/task-app-starters-micrometer-common/src/test/java/org/springframework/cloud/task/app/micrometer/common/SpringCloudTaskMicrometerEnvironmentPostProcessorTest.java
+++ b/task-app-starters-common/task-app-starters-micrometer-common/src/test/java/org/springframework/cloud/task/app/micrometer/common/SpringCloudTaskMicrometerEnvironmentPostProcessorTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.cloud.task.app.micrometer.common;
+
+import org.hamcrest.core.Is;
+import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+
+import org.springframework.core.env.PropertySource;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+
+/**
+ * @author Christian Tzolov
+ */
+@RunWith(Enclosed.class)
+public class SpringCloudTaskMicrometerEnvironmentPostProcessorTest {
+
+	public static class TestDefaultMetricsEnabledProperties extends AbstractMicrometerTagTest {
+
+		@Test
+		public void testDefaultProperties() {
+			assertNotNull(context);
+
+			PropertySource propertySource = context.getEnvironment().getPropertySources()
+					.get(SpringCloudTaskMicrometerEnvironmentPostProcessor.PROPERTY_SOURCE_KEY_NAME);
+
+			assertNotNull("Property source "
+							+ SpringCloudTaskMicrometerEnvironmentPostProcessor.PROPERTY_SOURCE_KEY_NAME + " is null",
+					propertySource);
+
+			assertThat(propertySource.getProperty("management.metrics.export.influx.enabled"), Is.is("false"));
+			assertThat(propertySource.getProperty("management.metrics.export.prometheus.enabled"), Is.is("false"));
+			assertThat(propertySource.getProperty("management.metrics.export.datadog.enabled"), Is.is("false"));
+
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.influx.enabled"), Is.is("false"));
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.prometheus.enabled"), Is.is("false"));
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.datadog.enabled"), Is.is("false"));
+		}
+	}
+
+	@TestPropertySource(properties = {
+			"management.metrics.export.simple.enabled=true",
+			"management.metrics.export.influx.enabled=true",
+			"management.metrics.export.prometheus.enabled=true",
+			"management.metrics.export.datadog.enabled=true",
+			"management.endpoints.web.exposure.include=info,health" })
+	public static class TestOverrideMetricsEnabledProperties extends AbstractMicrometerTagTest {
+
+		@Test
+		public void testOverrideProperties() {
+			assertNotNull(context);
+
+			PropertySource propertySource = context.getEnvironment().getPropertySources()
+					.get(SpringCloudTaskMicrometerEnvironmentPostProcessor.PROPERTY_SOURCE_KEY_NAME);
+
+			assertNull("Property source "
+							+ SpringCloudTaskMicrometerEnvironmentPostProcessor.PROPERTY_SOURCE_KEY_NAME + " is not null",
+					propertySource);
+
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.influx.enabled"), Is.is("true"));
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.prometheus.enabled"), Is.is("true"));
+			assertThat(context.getEnvironment().getProperty("management.metrics.export.datadog.enabled"), Is.is("true"));
+
+			assertThat(context.getEnvironment().getProperty("management.endpoints.web.exposure.include"), Is.is("info,health"));
+		}
+	}
+}


### PR DESCRIPTION
 - Extends the SCT micrometer support.
 - Add post-processor to disable the influx/prometheus by default.
 - Add task apps core global dependencies on influx, prometheus.
 
Resolves #14
Depends on spring-cloud/spring-cloud-task/issues/608
